### PR TITLE
UCJEPS-390: Adding input file type accept=image/*,video/*,audio/*,text/plain,application/pdf

### DIFF
--- a/src/main/webapp/tenants/ucjeps/html/components/MediaUploaderTemplate.html
+++ b/src/main/webapp/tenants/ucjeps/html/components/MediaUploaderTemplate.html
@@ -17,7 +17,7 @@
                     <div class="cs-mediaUploader-table-row">
                         <span class="csc-mediaUploader-uploadButton">
                             <span class="csc-mediaUploader-uploadButtonLabel"></span>
-                            <input class="csc-mediaUploader-uploadButtonInput" type="file">
+                            <input class="csc-mediaUploader-uploadButtonInput" type="file" accept="image/*,video/*,audio/*,text/plain,application/pdf">
                         </span>
                     </div>
                 </div>


### PR DESCRIPTION
Ray -

This is my recommendation for how we should set the media upload input field. See my (extensive) comments on the JIRA. It might change on Monday morning when I sit with the UCJEPS folks _if_ their computers recognize .CR2 as an image type; in that case, we should switch this setting to 'accept="image/jpg, video/*,...."' (If, as per the Bugzilla thread I've cited in the JIRA, OS's add file types to their list of known mime-types when software is installed, then I'd guess that the UCJEPS computers with Canon Digital Photo Professional installed will recognize .CR2, which is the camera raw format used by Canon.)

Anyway, if you feel confident about this, please deploy to ucjeps.cspace.berkeley.edu before Monday am.

Thanks,
Rick
