### PR TITLE
UCJEPS-392: HACK -- temporarily hardcoding display format to be OriginalJpeg (rather than Original) because we can't get app-layer configuration to work in v3.2

### DIFF
--- a/src/main/webapp/tenants/ucjeps/js/MediaView.js
+++ b/src/main/webapp/tenants/ucjeps/js/MediaView.js
@@ -223,7 +223,7 @@ cspace = cspace || {};
             if (!url) {
                 return url;
             }
-            return url.replace(/Thumbnail/, format || "Original");
+            return url.replace(/Thumbnail/, format || "OriginalJpeg");
         };
 
         // Function to return if record has the primary media


### PR DESCRIPTION
Ray -

I realize this is a hack until we can troubleshoot the app-layer config, but without it, there's a good chance that the UCJEPS folks will return to cataloging Monday morning and the images from which they get their cataloging information will be the pre-rotated Originals, stopping them in their tracks. Please deploy this change to ucjeps.cspace.berkeley.edu by Monday, if you aren't horrified by my approach.

If you follow my JIRA notes, I think I've identified the .js code that should be manipulated by the app-layer config. Perhaps you can trace from the app-layer to this code. Anyway, my available time this weekend is running out. 

Thanks,
Rick
