### PR TITLE
UCJEPS-388: Configuring Taxon autocomplete miniview popup to show displa...

### DIFF
--- a/src/main/webapp/tenants/ucjeps/bundle/core-messages.properties-overlay
+++ b/src/main/webapp/tenants/ucjeps/bundle/core-messages.properties-overlay
@@ -68,7 +68,10 @@ taxon-relatedTermLabel: Related Term
 taxon-relatedTermTypeLabel: Type
 taxon-relatedTermSourceLabel: Source
 taxon-relatedTermSourceDetailLabel: Source Detail
-
+taxon-miniView-field1Label: Term Type: 
+taxon-miniView-field2Label: Term Status: 
+taxon-miniView-field3Label: Rank:  
+taxon-miniView-field4Label: Major Group:  
 #Login
 login-current-info: 
 login-login: admin@ucjeps.cspace.berkeley.edu

--- a/src/main/webapp/tenants/ucjeps/js/Demands.js
+++ b/src/main/webapp/tenants/ucjeps/js/Demands.js
@@ -376,6 +376,7 @@ https://source.collectionspace.org/collection-space/LICENSE.txt
         fluid.demands("cspace.autocomplete.popup.miniView.urnToCSID", ["cspace.autocomplete.popup.miniView", "location-miniView"], authUrnToCSID);
         fluid.demands("cspace.autocomplete.popup.miniView.urnToCSID", ["cspace.autocomplete.popup.miniView", "concept-miniView"], authUrnToCSID);
         fluid.demands("cspace.autocomplete.popup.miniView.urnToCSID", ["cspace.autocomplete.popup.miniView", "place-miniView"], authUrnToCSID);
+        fluid.demands("cspace.autocomplete.popup.miniView.urnToCSID", ["cspace.autocomplete.popup.miniView", "taxon-miniView"], authUrnToCSID);
         fluid.demands("cspace.autocomplete.popup.miniView.renderer", ["cspace.autocomplete.popup.miniView", "person-miniView"], {
             options: {
                 protoTree: {
@@ -444,6 +445,32 @@ https://source.collectionspace.org/collection-space/LICENSE.txt
                 }
             }
         });
+        fluid.demands("cspace.autocomplete.popup.miniView.renderer", ["cspace.autocomplete.popup.miniView", "taxon-miniView"], {
+            options: {
+                protoTree: {
+                    displayName: {
+                        target: "${miniView-link}",
+                        linktext: "${fields.termDisplayName}"
+                    },
+                    field1: "${fields.taxonTermGroup.0.termType}",
+                    field2: "${fields.taxonTermGroup.0.termStatus}",
+                    field3: "${fields.taxonRank}",
+                    field4: "${fields.taxonMajorGroup}",
+                    field1Label: {
+                        messagekey: "taxon-miniView-field1Label"
+                    },
+                    field2Label: {
+                        messagekey: "taxon-miniView-field2Label"
+                    },
+                    field3Label: {
+                        messagekey: "taxon-miniView-field3Label"
+                    },
+                    field4Label: {
+                        messagekey: "taxon-miniView-field4Label"
+                    }
+                }
+            }
+        });        
         fluid.demands("cspace.autocomplete.popup.miniView.renderer", ["cspace.autocomplete.popup.miniView", "cataloging-miniView"], {
             options: {
                 toCSID: "cspace.util.urnToCSID",
@@ -490,6 +517,7 @@ https://source.collectionspace.org/collection-space/LICENSE.txt
         fluid.demands("cspace.autocomplete.popup.miniView.dataSource", ["cspace.autocomplete.popup.miniView", "location-miniView"], authDataSourceDemands);
         fluid.demands("cspace.autocomplete.popup.miniView.dataSource", ["cspace.autocomplete.popup.miniView", "concept-miniView"], authDataSourceDemands);
         fluid.demands("cspace.autocomplete.popup.miniView.dataSource", ["cspace.autocomplete.popup.miniView", "place-miniView"], authDataSourceDemands);
+        fluid.demands("cspace.autocomplete.popup.miniView.dataSource", ["cspace.autocomplete.popup.miniView", "taxon-miniView"], authDataSourceDemands);
         fluid.demands("cspace.autocomplete.authoritiesDataSource", "cspace.autocomplete", {
             funcName: "cspace.URLDataSource",
             args: {


### PR DESCRIPTION
...y name, type, status, rank and major group.

Ray -

This may be not-ready-for-prime-time. Merge if you wish, but feel free to wait, for three reasons:
1. Nothing is harmed by delaying
2. I've chosen to display the term display name and four fields, but I haven't consulted with the domain experts about which values would be useful. I can do that next week. So, the fields displayed might change.
3. I'd really like to show the vocabulary from which the suggested term comes, but I couldn't figure out how to address that bit of data. Maybe you and/or Amy could help me figure that one out.

Nonetheless, nothing is harmed by this push, and it is a nice display of v3.2's potential.

Thanks,
Rick
