### PR TITLE
UCJEPS-392: Merging in updated ucjeps_3.2 branch; modifying wro-ucjeps.x...

### DIFF
--- a/src/wro-ucjeps.xml
+++ b/src/wro-ucjeps.xml
@@ -214,6 +214,7 @@
     <js>/defaults/js/Tabs.js</js>
     <js>/defaults/js/ExternalURL.js</js>
     <js>/defaults/js/MediaView.js</js>
+    <js>/tenants/ucjeps/js/MediaView.js</js>
     <js>/defaults/js/MediaUploader.js</js>
     <js>/defaults/js/Hierarchy.js</js>
     <js>/defaults/js/ReportProducer.js</js>
@@ -268,6 +269,7 @@
     <js>/defaults/js/MediaUploader.js</js>
     <js>/defaults/js/ExternalURL.js</js>
     <js>/defaults/js/MediaView.js</js>
+    <js>/tenants/ucjeps/js/MediaView.js</js>
     <js>/defaults/js/Hierarchy.js</js>
     <js>/defaults/js/PageBuilder.js</js>
     <js>/defaults/lib/datejs/src/globalization/en-US.js</js>


### PR DESCRIPTION
...ml file so change propagates to production server.

Ray - 

The MediaView.js change we pushed yesterday to pop up the OriginalJpeg did not take effect.  I believe the reason is that /tenants/js/MediaView.js did not exist in the wro-ucjeps.xml (minimize js) file. I've added it here, to two groups -- record and template. (Those were the only two places that /defaults/js/MediaView.js existed.) 

This should rectify the problem, but I have no way to check it on my local stack. Please review this carefully.

Thanks!
Rick

ps - I've updated this branch from the cspace_deployment/ui/ucjeps_3.2 branch this morning, so all of the weekend's changes should be incorporated.
