### PR TITLE
UCJEPS-370: BerkeleyMapperIntegration UI Component added

### DIFF
--- a/src/main/webapp/defaults/css/cspace.css
+++ b/src/main/webapp/defaults/css/cspace.css
@@ -85,6 +85,9 @@ div.info-column2-50 table input[type="text"], div.info-column2-50 table input[ty
 table input[type="text"], table input[type="password"], table textarea {
     width:100%;
     padding-left:2px;}
+button.csc-berkeleyMapper-btn {
+    vertical-align: middle;
+}
 input[type="submit"].logout {
     font-weight:bold; 
     color:#333; 
@@ -96,7 +99,7 @@ input[type="submit"].logout:hover,
 input[type="submit"].logout:focus {
     background-color:#333; 
     color:#FFF;}
-input[type="button"], input[type="submit"]  {
+input[type="button"], input[type="submit"], button.csc-berkeleyMapper-btn  {
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
     background-color:#73AA4F; 
     height:21px; 
@@ -109,7 +112,7 @@ input[type="button"], input[type="submit"]  {
     line-height:13px; 
     border:none;}
 input[type="button"]:hover, input[type="submit"]:hover,
-input[type="button"]:focus, input[type="submit"]:focus {
+input[type="button"]:focus, input[type="submit"]:focus, button.csc-berkeleyMapper-btn:hover {
     background-color:#48722D;}
 input[type="button"].saveButton, input[type="submit"].saveButton {
     background:#73AA4F url('../images/icnSave.png') no-repeat 24px 4px; 
@@ -255,7 +258,7 @@ input.secondaryButton:focus, input.secondaryButton:hover {
     display: table-cell;
     vertical-align: middle;
 }
-.button-row input[type="button"], .button-row-right input[type="button"], .button-row a, .button-row-right a {
+.button-row input[type="button"], .button-row-right input[type="button"], .button-row a, .button-row-right a, button.csc-berkeleyMapper-btn {
     margin-left:10px; 
     box-shadow: 0 1px 4px rgba(0, 0, 0, 0.3);
     /*float:right; */
@@ -1555,7 +1558,7 @@ input[type="text"].cs-externalURL.cs-externalURL-error{
     -webkit-border-radius:0;
 	border-radius:0;}
 
-.saveButton, .createFromExistingButton, .cs-searchBox-button, .csc-header-logout, .csc-search-submit, .csc-add-related-record-button, .csc-show-related-records-button, .csc-numberPatternChooser-button, .cs-createNew-createButton, .cs-createNew-createTemplateButton, .cs-messageBar-cancel, .cs-confirmationDialogButton, .cs-user-searchButton, .cs-user-unSearchButton, .cs-searchToRelate-createButton, .cs-searchToRelate-addButton, .cs-createTemplateBox-createButton, .cs-advancedSearch-searchButton, .cs-relateSearchResults-relateButton {
+.saveButton, .createFromExistingButton, .cs-searchBox-button, .csc-header-logout, .csc-search-submit, .csc-add-related-record-button, .csc-show-related-records-button, .csc-numberPatternChooser-button, .cs-createNew-createButton, .cs-createNew-createTemplateButton, .cs-messageBar-cancel, .cs-confirmationDialogButton, .cs-user-searchButton, .cs-user-unSearchButton, .cs-searchToRelate-createButton, .cs-searchToRelate-addButton, .cs-createTemplateBox-createButton, .cs-advancedSearch-searchButton, .cs-relateSearchResults-relateButton, button.csc-berkeleyMapper-btn {
     -moz-border-radius:4px; 
     -webkit-border-radius:4px;
 	border-radius:4px;

--- a/src/main/webapp/defaults/html/record.html
+++ b/src/main/webapp/defaults/html/record.html
@@ -66,6 +66,7 @@
         <script type="text/javascript" src="../js/DatePicker.js"></script>
         <script type="text/javascript" src="../js/RecordTraverser.js"></script>
         <script type="text/javascript" src="../tools/uispecVerifier/js/uispecVerifier.js"></script>
+        <script type="text/javascript" src="../js/BerkeleyMapperIntegration.js"></script>
     </head>
 
     <body class="record">

--- a/src/main/webapp/defaults/js/BerkeleyMapperIntegration.js
+++ b/src/main/webapp/defaults/js/BerkeleyMapperIntegration.js
@@ -1,0 +1,70 @@
+/* Copyright 2011 University of California, Berkeley; Museum of Moving Image
+
+Licensed under the Educational Community License (ECL), Version 2.0. You may not use this file except in compliance with this License.
+
+You may obtain a copy of the ECL 2.0 License at https://source.collectionspace.org/collection-space/LICENSE.txt */
+
+/*global jQuery, fluid, window, cspace:true*/
+"use strict";
+
+var cspace = cspace || {};
+
+(function($, fluid) {
+    
+    //TODO: Design Discussion: potentially this should be a component of the sidebar, instead of a component of the recordEditor?
+
+    fluid.defaults("cspace.berkeleyMapperIntegration", {
+        gradeNames: ["fluid.modelComponent", "autoInit"],
+        model: "{recordEditor}.model",
+        parentBundle: "{globalBundle}",
+        finalInitFunction: "cspace.berkeleyMapperIntegration.finalInit",
+        components: {
+             globalModel: "{globalModel}"
+        },
+        recordType: "{recordEditor}.options.recordType",
+        berkeleyMapperBtn: ".csc-berkeleyMapper-btn",
+        reportName: "berkeleyMapperTest",
+        urls: cspace.componentUrlBuilder({
+            reportUrl: "%tenant/%tname/invokereport/%reportcsid/%recordType/%csid/publish",
+            configUrl: "%webapp/config/BerkeleyMapperConfig-%recordType.xml",
+            tabfileUrl: "%services%publicItemCsid/%tId/content/"
+        })
+    });
+    
+    cspace.berkeleyMapperIntegration.finalInit = function(that) {
+        $('.secondary-nav-menu-sub .button-row').append('<button type="button" class="csc-berkeleyMapper-btn">Map with BerkeleyMapper</button>');
+
+        $(that.options.berkeleyMapperBtn).click(function(me) {
+            return function() {
+                //TODO: Figure out an alternate way of getting the CSID of the BerkeleyMapper report
+                var reportTypeSelection = $('#reportType-selection option').filter(function(index) {
+                    return $(this).text() == me.options.reportName;
+                }).val();
+
+                var reportUrl = fluid.stringTemplate(me.options.urls.reportUrl, {
+                    reportcsid: reportTypeSelection,
+                    recordType: me.options.recordType,
+                    csid: me.globalModel.model.primaryModel.csid
+                });
+                
+                //TODO: this should be a POST with json payload to support mapping multiple items down the road
+                $.get(reportUrl, function(data, textStatus, jqXHR) {
+                    if (textStatus == "success") {
+                        //TODO: where should the config file live? 
+                        var configfile = fluid.stringTemplate(me.options.urls.configUrl, {
+                            recordType: me.options.recordType
+                        });
+                        
+                        var tabfile = fluid.stringTemplate(me.options.urls.tabfileUrl, {
+                            publicItemCsid: jqXHR.getResponseHeader("Location"),
+                            tId: me.model.fields.tenantId
+                        });
+                        
+                        window.open("http://berkeleymapper.berkeley.edu/index.html?ViewResults=tab&tabfile=" + tabfile + "&configfile=" + configfile);
+                    }
+                });
+            }
+        }(that));
+    };
+
+})(jQuery, fluid);

--- a/src/main/webapp/defaults/js/Utilities.js
+++ b/src/main/webapp/defaults/js/Utilities.js
@@ -163,7 +163,8 @@ fluid.registerNamespace("cspace.util");
                 }
             },
             webapp: "..",
-            test: "../../../../test"
+            test: "../../../../test",
+            services: "../../../../cspace-services"
         }
     });
 


### PR DESCRIPTION
Added {{BerkeleyMapperIntegration.js}}, as well as the appropriate {{<script>}} tag in {{record.html}} to add it to the list, a few styles in {{cspace.css}} to support styling the berkeley mapper button, and a line in {{Utilities.js}} to add the {{cspace-services}} url, used in the {{BerkeleyMapperIntegration}} component. 

Currently, all this code, as well as some tenant-specific configuration in {{cataloging.json}} to add a BerkeleyMapper button to cataloging records, is checked in to {{cspace-deployments/botgarden_3.2_berkeleymapper}} - look at the compare view here: https://github.com/cspace-deployment/ui/compare/botgarden_3.2...botgarden_3.2_berkeleymapper In order to make it all work, in addition to the afore-mentioned configuration, you must have a report in tomcat, and you must load a report record into the database called {{BerkeleyMapperTest}} for the {{CollectionObject}} doctype with the filename property the same as the report's file name (the report must be written in a corresponding format to the {{BerkeleyMapperConfig-cataloging.xml}} file in {{cspace-deployments/botgarden_3.2_berkeleymapper}}). Finally, in order to truly test, this must be on a server somewhere so that BerkeleyMapper can actually retrieve the relevant resources. For this reason, perhaps the modification made to {{record.html}} here should actually be a tenant-specific modification (or perhaps none of this should go into the {{v3.2}} branch at all and instead should go into {{ucjeps_3.2}}) 
