### PR TITLE
PAHMA-1494: Display Previous Owner in Acquisition titlebar

### DIFF
--- a/src/main/webapp/tenants/pahma/config/aquisition.json
+++ b/src/main/webapp/tenants/pahma/config/aquisition.json
@@ -1,0 +1,53 @@
+{
+    "pageBuilder": {
+        "options": {
+            "pageType": "acquisition",
+            "components": {
+                "recordEditor": {
+                    "type":  "cspace.recordEditor",
+                    "options": {
+                        "selectors": {
+                            "identificationNumber": ".csc-acquisition-numberPatternChooser-reference-number" 
+                        },
+                        "uispec": "{pageBuilder}.options.uispec.recordEditor",
+                        "fieldsToIgnore": ["csid", "fields.csid", "fields.createdAt", "fields.createdBy", "fields.updatedAt", "fields.updatedBy", "fields.acquisitionReferenceNumber"]
+                    }
+                },
+                "titleBar": {
+                    "type": "cspace.titleBar",
+                    "options": {
+                        "fields": [
+                            "fields.acquisitionReferenceNumber", {
+                            "type": "repeatableMatch",
+                            "queryPath": "fields.acquisitionDonorGroup",
+                            "childPath": "_primary",
+                            "value": true,
+                            "path": "donor"
+                        }]
+                    }
+                },
+                "header": {
+                    "type": "cspace.header",
+                    "options": {
+                        "schema": "{pageBuilder}.schema",
+                        "permissions": "{pageBuilder}.permissions"
+                    }
+                },
+                "tabs": {
+                    "type": "cspace.tabs"
+                },
+                "sidebar": {
+                    "type": "cspace.sidebar"
+                }
+            }
+        }
+    },
+    "pageBuilderIO": {
+        "options": {
+            "recordType": "acquisition",
+            "schema": {
+                "acquisition": null
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added a new json file to tenant with changes to display the Donor at the title bar.

Additionally, overrided mini for Acquisition Source, and added mini to Donor in Application.
