### PR TITLE
UCJEPS-661: Converted georefsource from textbox to list

### DIFF
--- a/src/main/webapp/tenants/ucjeps/html/components/LocalityTemplate.html
+++ b/src/main/webapp/tenants/ucjeps/html/components/LocalityTemplate.html
@@ -387,7 +387,8 @@
 								<div class="label csc-locality-geoRefSource-label"></div>
 							</div>
 							<div class="content">
-								<input type="text" class="csc-locality-geoRefSource" />
+								<select class="csc-locality-geoRefSource input-select"><option value="">Options not loaded</option></select>
+								<!-- Converted to list -->
 							</div>
 						</div>
 					</div>

--- a/src/main/webapp/tenants/ucjeps/html/pages/PlaceTemplate.html
+++ b/src/main/webapp/tenants/ucjeps/html/pages/PlaceTemplate.html
@@ -1,0 +1,581 @@
+<div class="fl-container-flex fl-fix information-group info-column oocss">
+    <div class="csc-recordEditor-header fl-container-flex header toggle csc-place-placeAuthorityInformation-label"></div>
+    <div class="csc-recordEditor-togglable fl-container-flex fl-fix content main">
+        
+        <div class="info-column">
+            <div class="info-pair">
+                <div class="header">
+                    <div class="label csc-place-preferredPlace-label"></div>
+                </div>
+                <div class="content">
+                    <div class="csc-preferred-placeAuthority cs-multipleEdit"></div>
+                </div>
+            </div>
+        </div>
+        
+        <!-- Row 1 -->
+        <div class="info-column">
+
+            <div class="size1of2 fl-force-left">
+                <div class="size1of3 fl-force-left">
+                    <div class="info-pair">
+                        <div class="header">
+                            <div class="label csc-place-placeType-label"></div>
+                        </div>
+                        <div class="content">
+                            <select class="csc-place-placeType input-select"><option value="">Options not loaded</option></select>
+                        </div>
+                    </div>
+                </div>
+                <!-- placeRecordAdminStatus ("Admin status") discarded in favor of ... -->
+                <!-- Term status field common to all authorities -->
+                <!--<div class="size1of4 fl-force-left">
+                    <div class="info-pair">
+                        <div class="header">
+                            <div class="label csc-place-placeRecordAdminStatus-label"></div>
+                        </div>
+                        <div class="content">
+                            <select class="csc-place-placeRecordAdminStatus input-select"><option value="">Options not loaded</option></select>
+                        </div>
+                    </div>
+                </div>-->
+        </div>
+      </div>
+	
+        <!-- Row 2 --><!-- Replace everything between previous 'Row 2' comment and this one if it is desirable to have a table with repeating rows instead of a repeating group -->
+        <!-- <div class="info-column">
+            <div class="info-pair">
+                <div class="header">
+                    <div class="label csc-place-placeNameGroup-label"></div>
+                </div>
+                <div class="content">
+                    <table>
+                        <thead>
+                            <tr>
+                                <td class="csc-place-name-label"></td>
+                                <td class="csc-place-nameQualifiedName-label"></td>
+                                <td class="csc-place-nameLanguage-label"></td>
+                                <td class="csc-place-nameAbbrev-label"></td>
+                                <td class="csc-place-nameType-label"></td>
+                                <td class="csc-place-nameStatus-label"></td>
+                                <td class="csc-place-nameSource-label"></td>
+                                <td class="csc-place-nameSourceDetail-label"></td>
+                                <td class="csc-place-nameSourceRefId-label"></td>
+                                <td class="csc-place-nameNote-label"></td>
+                                <td class="csc-place-nameDate-label"></td>
+                                <td class="csc-place-nameAdminStatus-label"></td>
+                            </tr>
+                        </thead>
+                        <tbody>
+                            <tr class="csc-place-placeNameGroup placeNames">
+                                <td class="flc-inlineEdit-text name">
+                                    <input type="text" class="csc-place-name editableText" />
+                                </td>
+                                <td class="flc-inlineEdit-text qualifiedName">
+                                    <input type="text" class="csc-place-nameQualifiedName editableText" />
+                                </td>
+                                <td class="flc-inlineEdit-text nameLanguage">
+                                    <select class="csc-place-nameLanguage">
+                                        <option value="">Options not loaded</option>
+                                    </select>
+                                </td>
+                                <td class="flc-inlineEdit-text nameAbbrev">
+                                    <input type="text" class="csc-place-nameAbbrev editableText" />
+                                </td>
+                                <td class="flc-inlineEdit-text nameType">
+                                    <select class="csc-place-nameType">
+                                        <option value="">Options not loaded</option>
+                                    </select>
+                                </td>
+                                <td class="flc-inlineEdit-text nameStatus">
+                                    <select class="csc-place-nameStatus">
+                                        <option value="">Options not loaded</option>
+                                    </select>
+                                </td>
+                                <td class="flc-inlineEdit-text nameSource">
+                                    <input type="text" class="csc-place-nameSource editableText" />
+                                </td>
+                                <td class="flc-inlineEdit-text nameSourceDetail">
+                                    <input type="text" class="csc-place-nameSourceDetail editableText" />
+                                </td>
+                                <td class="flc-inlineEdit-text nameSourceRefId">
+                                    <input type="text" class="csc-place-nameSourceRefId editableText" />
+                                </td>
+                                <td class="flc-inlineEdit-text nameNote">
+                                    <input type="text" class="csc-place-nameNote editableText" />
+                                </td>
+                                <td class="flc-inlineEdit-text nameDate">
+                                    <input type="text" class="csc-place-nameDate editableText" />
+                                </td>
+                                <td class="flc-inlineEdit-text nameAdminStatus">
+                                    <select class="csc-place-nameAdminStatus">
+                                        <option value="">Options not loaded</option>
+                                    </select>
+                                </td>
+                            </tr>
+                        </tbody>
+                    </table>                           
+                </div>
+            </div>
+        </div> -->
+		
+        <!-- Row 3 -->
+        <div class="info-column">
+            <div class="size1of2 fl-force-left">
+                <div class="info-pair">
+                    <div class="header">
+                        <div class="label csc-place-placeOwnerGroup-label"></div>
+                    </div>
+                    <div class="content">
+                        <table>
+                            <thead>
+                                <tr>
+                                    <td class="csc-place-owner-label"></td>
+                                    <td class="csc-placeOwnerGroup-ownershipDateGroup-label"></td>
+                                    <td class="csc-place-ownershipNote-label"></td>
+                                </tr>
+                            </thead>
+                            <tbody>
+                                <tr class="csc-place-placeOwnerGroup placeOwner">
+                                    <td class="owner">
+                                        <input type="text" class="csc-place-owner"/>
+                                        <div class="csc-place-owner-autocomplete"></div>
+                                    </td>
+                                    <td class="flc-inlineEdit-text ownershipDate">
+                                        <input type="text" class="csc-placeOwnerGroup-ownershipDateGroup editableText" />
+                                    </td>
+                                    <td class="flc-inlineEdit-text ownershipNote">
+                                        <input type="text" class="csc-place-ownershipNote editableText" />
+                                    </td>
+                                </tr>
+                            </tbody>
+                        </table>
+                    </div>
+                </div>
+                <div class="info-pair">
+                    <div class="header">
+                        <div class="label csc-place-placeSource-label"></div>
+                    </div>
+                    <div class="content">
+                        <input type="text" class="csc-place-placeSource" />
+                    </div>
+                </div>
+            </div>
+            <div class="size1of2 fl-force-left">
+                <div class="info-pair">
+                    <div class="header">
+                        <div class="label csc-place-placeNote-label"></div>
+                    </div>
+                    <div class="content">
+                        <textarea rows="4" cols="30" class="input-textarea csc-place-placeNote"></textarea>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="clear"></div>
+    </div>
+</div>
+
+<div class="fl-container-flex fl-fix information-group oocss">
+    <div class="csc-recordEditor-header fl-container-flex header toggle csc-place-localityInformation-label"></div>
+    <div class="csc-recordEditor-togglable fl-container-flex fl-fix content main">
+        <div class="info-column">
+
+            <!-- Row 1 -->
+            <div class="info-column fl-force-left">
+                <div class="size1of6 fl-force-left" >
+                    <div class="info-pair">
+                        <div class="header">
+                            <div class="label csc-place-vCoordinates-label"></div>
+                        </div>
+                        <div class="content">
+                            <input type="text" class="csc-place-vCoordinates" />
+                        </div>
+                    </div>
+                </div>
+                <div class="size1of6 fl-force-left">
+                    <div class="info-pair">
+                        <div class="header">
+                            <div class="label csc-place-vLatitude-label"></div>
+                        </div>
+                        <div class="content">
+                            <input type="text" class="csc-place-vLatitude" />
+                        </div>
+                    </div>
+                </div>
+                <div class="size1of6 fl-force-left" >
+                    <div class="info-pair">
+                        <div class="header">
+                            <div class="label csc-place-vLongitude-label"></div>
+                        </div>
+                        <div class="content">
+                            <input type="text" class="csc-place-vLongitude" />
+                        </div>
+                    </div>
+                </div>
+                <div class="size1of2 fl-force-left">
+                    <div class="size1of2 fl-force-left">
+                        <div class="info-pair">
+                            <div class="header">
+                                <div class="label csc-place-vCoordSys-label"></div>
+                            </div>
+                            <div class="content">
+                                <select class="csc-place-vCoordSys input-select"><option value="">Options not loaded</option></select>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="size1of2 fl-force-left" >
+                        <div class="info-pair">
+                            <div class="header">
+                                <div class="label csc-place-vSpatialReferenceSystem-label"></div>
+                            </div>
+                            <div class="content">
+                                <select class="csc-place-vSpatialReferenceSystem input-select"><option value="">Options not loaded</option></select>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+
+            <!-- Row 2 -->
+            <div class="info-column fl-force-left">
+                <div class="size1of6 fl-force-left" >
+                    <div class="info-pair">
+                        <div class="header">
+                            <div class="label csc-place-vElevation-label"></div>
+                        </div>
+                        <div class="content">
+                            <input type="text" class="csc-place-vElevation" />
+                        </div>
+                    </div>
+                </div>
+                <div class="size1of6 fl-force-left" >
+                    <div class="info-pair">
+                        <div class="header">
+                            <div class="label csc-place-vDepth-label"></div>
+                        </div>
+                        <div class="content">
+                            <input type="text" class="csc-place-vDepth" />
+                        </div>
+                    </div>
+                </div>
+                <div class="size1of6 fl-force-left" >
+                    <div class="info-pair">
+                        <div class="header">
+                            <div class="label csc-place-vDistanceAboveSurface-label"></div>
+                        </div>
+                        <div class="content">
+                            <input type="text" class="csc-place-vDistanceAboveSurface" />
+                        </div>
+                    </div>
+                </div>
+                <div class="size1of2 fl-force-left">
+                    <div class="size1of2 fl-force-left" >
+                        <div class="info-pair">
+                            <div class="header">
+                                <div class="label csc-place-vUnitofMeasure-label"></div>
+                            </div>
+                            <div class="content">
+                                <select class="csc-place-vUnitofMeasure input-select"><option value="">Options not loaded</option></select>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>				
+
+        <!-- Rows 3 and 4 in a column-based layout -->
+        <div class="info-column fl-force-left">
+            <div class="size1of2 fl-force-left">
+
+                <!-- Column 1 -->
+                <div class="info-column fl-force-left size1of3">
+                    <div class="info-pair">
+                        <div class="header">
+                            <div class="label csc-place-minElevationInMeters-label"></div>
+                        </div>
+                        <div class="content smallfield">
+                            <input type="text" class="csc-place-minElevationInMeters" />
+                        </div>
+                    </div>
+                    <div class="info-pair">
+                        <div class="header">
+                            <div class="label csc-place-maxElevationInMeters-label"></div>
+                        </div>
+                        <div class="content smallfield">
+                            <input type="text" class="csc-place-maxElevationInMeters" />
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Column 2 -->
+                <div class="info-column fl-force-left size1of3">
+                    <div class="info-pair">
+                        <div class="header">
+                            <div class="label csc-place-minDepthInMeters-label"></div>
+                        </div>
+                        <div class="content smallfield">
+                            <input type="text" class="csc-place-minDepthInMeters" />
+                        </div>
+                    </div>
+            
+                    <div class="info-pair">
+                        <div class="header">
+                            <div class="label csc-place-maxDepthInMeters-label"></div>
+                        </div>
+                        <div class="content smallfield">
+                            <input type="text" class="csc-place-maxDepthInMeters" />
+                        </div>
+                    </div>
+                </div>
+
+                <!-- Column 3 -->
+                <div class="info-column fl-force-left size1of3">
+                    <div class="info-pair">
+                        <div class="header">
+                            <div class="label csc-place-minDistanceAboveSurfaceInMeters-label"></div>
+                        </div>
+                        <div class="content smallfield">
+                            <input type="text" class="csc-place-minDistanceAboveSurfaceInMeters" />
+                        </div>
+                    </div>
+                    <div class="info-pair">
+                        <div class="header">
+                            <div class="label csc-place-maxDistanceAboveSurfaceInMeters-label"></div>
+                        </div>
+                        <div class="content smallfield">
+                            <input type="text" class="csc-place-maxDistanceAboveSurfaceInMeters" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+            <div class="size1of2 fl-force-left">
+                <!-- vertical spacer for row 3 so source and source detail appear on row 4 -->
+                <div class="size1of1 fl-force-left spacer"></div>
+                <div class="size1of2 fl-force-left">
+                    <div class="info-pair">
+                        <div class="header">
+                            <div class="label csc-place-vCoordSource-label"></div>
+                        </div>
+                        <div class="content">
+                            <input type="text" class="csc-place-vCoordSource" />
+                        </div>
+                    </div>
+                </div>
+                <div class="size1of2 fl-force-left" >
+                    <div class="info-pair">
+                        <div class="header">
+                            <div class="label csc-place-vCoordSourceRefId-label"></div>
+                        </div>
+                        <div class="content">
+                            <input type="text" class="csc-place-vCoordSourceRefId" />
+                        </div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div class="clear"></div>
+    </div>
+</div>
+
+<div class="fl-container-flex fl-fix information-group oocss">
+    <div class="csc-recordEditor-header fl-container-flex header toggle csc-place-geoReferenceInformation-label"></div>
+    <div class="csc-recordEditor-togglable fl-container-flex fl-fix content main">
+        <div class="info-column cs-multipleEdit">
+            <div class="info-pair">
+                <div class="header">
+                    <div class="label"><br></div>
+                </div>
+                <div class="content csc-place-placeGeoRefGroup"><!-- This ties to app layer, gets repeat decorations -->
+                    <div class="info-column fieldgroup">
+
+                        <!-- Row 1 -->
+                        <div class="info-column fl-force-left">
+                            <div class="size1of5 fl-force-left">
+                                <div class="info-pair ">
+                                    <div class="header">
+                                        <div class="label csc-place-decimalLatitude-label"></div>
+                                    </div>
+                                    <div class="content">
+                                        <input type="text" class="csc-place-decimalLatitude" />
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="size1of5 fl-force-left">
+                                <div class="info-pair">
+                                    <div class="header">
+                                        <div class="label csc-place-decimalLongitude-label"></div>
+                                    </div>
+                                    <div class="content">
+                                        <input type="text" class="csc-place-decimalLongitude" />
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="size1of5 fl-force-left">
+                                <div class="info-pair">
+                                    <div class="header">
+                                        <div class="label csc-place-geodeticDatum-label"></div>
+                                    </div>
+                                    <div class="content">
+                                        <select class="csc-place-geodeticDatum input-select"><option value="">Options not loaded</option></select>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="size1of5 fl-force-left">
+                                <div class="info-pair">
+                                    <div class="header">
+                                        <div class="label csc-place-coordUncertaintyInMeters-label"></div>
+                                    </div>
+                                    <div class="content">
+                                        <input type="text" class="csc-place-coordUncertaintyInMeters" />
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="size1of5 fl-force-left">
+                                <div class="info-pair">
+                                    <div class="header">
+                                        <div class="label csc-place-coordPrecision-label"></div>
+                                    </div>
+                                    <div class="content">
+                                        <input type="text" class="csc-place-coordPrecision" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="clear"></div>
+
+                        <!-- Row 2 -->
+                        <div class="info-column fl-force-left">
+                            <div class="size1of5 fl-force-left">
+                                <div class="info-pair ">
+                                    <div class="header">
+                                        <div class="label csc-place-pointRadiusSpatialFit-label"></div>
+                                    </div>
+                                    <div class="content">
+                                        <input type="text" class="csc-place-pointRadiusSpatialFit" />
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="size1of5 fl-force-left">
+                                <div class="info-pair">
+                                    <div class="header">
+                                        <div class="label csc-place-footprintWKT-label"></div>
+                                    </div>
+                                    <div class="content">
+                                        <input type="text" class="csc-place-footprintWKT" />
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="size1of5 fl-force-left">
+                                <div class="info-pair">
+                                    <div class="header">
+                                        <div class="label csc-place-footprintSRS-label"></div>
+                                    </div>
+                                    <div class="content">
+                                        <input type="text" class="csc-place-footprintSRS" />
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="size1of5 fl-force-left">
+                                <div class="info-pair">
+                                    <div class="header">
+                                        <div class="label csc-place-footprintSpatialFit-label"></div>
+                                    </div>
+                                    <div class="content">
+                                        <input type="text" class="csc-place-footprintSpatialFit" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="clear"></div>
+
+                        <!-- Row 3 -->
+                        <div class="info-column fl-force-left">
+                            <div class="size1of5 fl-force-left">
+                                <div class="info-pair ">
+                                    <div class="header">
+                                        <div class="label csc-place-geoReferencedBy-label"></div>
+                                    </div>
+                                    <div class="content">
+                                        <input type="text" class="csc-place-geoReferencedBy" />
+                                        <div class="csc-place-geoReferencedBy-autocomplete"></div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="size1of5 fl-force-left">
+                                <div class="info-pair">
+                                    <div class="header">
+                                        <div class="label csc-placeGeoRefGroup-geoRefDateGroup-label"></div>
+                                    </div>
+                                    <div class="content">
+                                        <input type="text" class="csc-placeGeoRefGroup-geoRefDateGroup editableText" />
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="size1of5 fl-force-left">
+                                <div class="info-pair">
+                                    <div class="header">
+                                        <div class="label csc-place-geoRefProtocol-label"></div>
+                                    </div>
+                                    <div class="content">
+                                        <select class="csc-place-geoRefProtocol input-select"><option value="">Options not loaded</option></select>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="size1of5 fl-force-left">
+                                <div class="info-pair">
+                                    <div class="header">
+                                        <div class="label csc-place-geoRefSource-label"></div>
+                                    </div>
+                                    <div class="content">
+                                        <select class="csc-place-geoRefSource input-select"><option value="">Options not loaded</option></select>
+                                        <!-- Converted to list -->
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="size1of5 fl-force-left">
+                                <div class="info-pair">
+                                    <div class="header">
+                                        <div class="label csc-place-geoRefVerificationStatus-label"></div>
+                                    </div>
+                                    <div class="content">
+                                        <select class="csc-place-geoRefVerificationStatus input-select"><option value="">Options not loaded</option></select>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="clear"></div>
+
+                        <!-- Row 4 -->
+                        <div class="info-column fl-force-left">
+                            <div class="size2of5 fl-force-left">
+                                <div class="info-pair">
+                                    <div class="header">
+                                        <div class="label csc-place-geoRefRemarks-label"></div>
+                                    </div>
+                                    <div class="content">
+                                        <input type="text" class="csc-place-geoRefRemarks" />
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="size2of5 fl-force-left">
+                                <div class="info-pair">
+                                    <div class="header">
+                                        <div class="label csc-place-geoRefPlaceName-label"></div>
+                                    </div>
+                                    <div class="content">
+                                        <input type="text" class="csc-place-geoRefPlaceName" />
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <div class="clear"></div>
+                </div>
+            </div>
+            <div class="clear"></div>
+        </div>
+    </div>
+</div>
+
+<div class="csc-record-hierarchy"></div>


### PR DESCRIPTION
Edited the HTML to convert the textboxes to lists in two spots, cataloging and place. Had to create a UCJEPS tenant file for PlaceTemplate.html from the default to make the change.